### PR TITLE
fix: undefined web3 api key

### DIFF
--- a/src/providers/Web3.tsx
+++ b/src/providers/Web3.tsx
@@ -8,7 +8,7 @@ import { polygon, polygonMumbai } from '@wagmi/chains'
 import { alchemyProvider } from 'wagmi/providers/alchemy'
 import { jsonRpcProvider } from 'wagmi/providers/jsonRpc'
 
-const API_KEY = '4QdGUP8BOp3_NdNJAN1c2sWs12LtsfDF'
+const API_KEY = process.env.NEXT_PUBLIC_WEB3_API_KEY
 
 interface Props {
   children: ReactNode


### PR DESCRIPTION
Fixed env issue. we need to add the following to the `.env.local` file and restart the server afterwards.
`NEXT_PUBLIC_WEB3_API_KEY=4QdGUP8BOp3_NdNJAN1c2sWs12LtsfDF`